### PR TITLE
488 getlibs.batが動かない

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.bat diff=sjis
+*.ps1 diff=sjis
+

--- a/copylibs.ps1
+++ b/copylibs.ps1
@@ -1,3 +1,9 @@
+function removeIfExists($dir) {
+    if (Test-Path $dir) {
+        Remove-Item $dir -Recurse -Force
+    }
+}
+
 #LIBファイルを直下に、DLLファイルをdllフォルダにコピー
 Copy-Item bass24/c/bass.lib ./ -Force
 Copy-Item bass_aac24/c/bass_aac.lib ./ -Force
@@ -33,24 +39,24 @@ Copy-Item nezplug++/npnez.dll ./dll -Force
 Copy-Item mp3infp/x86/mp3infp.dll ./dll -Force
 
 #各展開ファイルをバックアップフォルダに移動して終了
-Remove-Item ./.backup/bass24 -Recurse -Force
-Remove-Item ./.backup/bass_aac24 -Recurse -Force
-Remove-Item ./.backup/bassalac24 -Recurse -Force
-Remove-Item ./.backup/bass_ape24 -Recurse -Force
-Remove-Item ./.backup/Hayaemon276 -Recurse -Force
-Remove-Item ./.backup/bass_fx24 -Recurse -Force
-Remove-Item ./.backup/bassasio13 -Recurse -Force
-Remove-Item ./.backup/basscd24 -Recurse -Force
-Remove-Item ./.backup/bassenc24 -Recurse -Force
-Remove-Item ./.backup/bassflac24 -Recurse -Force
-Remove-Item ./.backup/bassmix24 -Recurse -Force
-Remove-Item ./.backup/basswasapi24 -Recurse -Force
-Remove-Item ./.backup/basswm24 -Recurse -Force
-Remove-Item ./.backup/tags18 -Recurse -Force
-Remove-Item ./.backup/nezplug++ -Recurse -Force
-Remove-Item ./.backup/jpegsr9c -Recurse -Force
-Remove-Item ./.backup/7za920 -Recurse -Force
-Remove-Item ./.backup/mp3infp -Recurse -Force
+removeIfExists ./.backup/bass24
+removeIfExists ./.backup/bass_aac24
+removeIfExists ./.backup/bassalac24
+removeIfExists ./.backup/bass_ape24
+removeIfExists ./.backup/Hayaemon276
+removeIfExists ./.backup/bass_fx24
+removeIfExists ./.backup/bassasio13
+removeIfExists ./.backup/basscd24
+removeIfExists ./.backup/bassenc24
+removeIfExists ./.backup/bassflac24
+removeIfExists ./.backup/bassmix24
+removeIfExists ./.backup/basswasapi24
+removeIfExists ./.backup/basswm24
+removeIfExists ./.backup/tags18
+removeIfExists ./.backup/nezplug++
+removeIfExists ./.backup/jpegsr9c
+removeIfExists ./.backup/7za920
+removeIfExists ./.backup/mp3infp
 Move-Item ./bass24 ./.backup/ -Force
 Move-Item ./bass_aac24 ./.backup/ -Force
 Move-Item ./bassalac24 ./.backup/ -Force

--- a/downloadlibs.ps1
+++ b/downloadlibs.ps1
@@ -7,7 +7,7 @@ $networkListManager = [Activator]::CreateInstance([Type]::GetTypeFromCLSID([Guid
 $connections = $networkListManager.GetNetworkConnections()
 $connections = $connections | ForEach-Object {$_.isConnectedToInternet}
 if ($connections -eq $TRUE) {
-	Write-Host 'ダウンロードを開始します'
+	Write-Host '各種ライブラリのダウンロードを開始します'
 }
 else {
 	Write-Warning 'インターネット接続を確認してください'
@@ -20,7 +20,7 @@ try {
 	Invoke-WebRequest -Uri http://uk.un4seen.com/files/z/2/bass_aac24.zip -OutFile bass_aac24.zip
 	Invoke-WebRequest -Uri http://uk.un4seen.com/files/bassalac24.zip -OutFile bassalac24.zip
 	Invoke-WebRequest -Uri http://uk.un4seen.com/files/z/2/bass_ape24.zip -OutFile bass_ape24.zip
-	Invoke-WebRequest -Uri http://soft.edolfzoku.com/hayaemon2/Hayaemon276.zip -OutFile Hayaemon276.zip
+	Invoke-WebRequest -Uri https://hayaemon.jp/Hayaemon276.zip -OutFile Hayaemon276.zip
 	Invoke-WebRequest -Uri http://uk.un4seen.com/files/z/0/bass_fx24.zip -OutFile bass_fx24.zip
 	Invoke-WebRequest -Uri http://uk.un4seen.com/files/bassasio13.zip -OutFile bassasio13.zip
 	Invoke-WebRequest -Uri http://uk.un4seen.com/files/basscd24.zip -OutFile basscd24.zip
@@ -38,21 +38,23 @@ try {
 catch {
 	if ( ($error | ForEach-Object {$_.Exception.Status}) -eq "ConnectFailure" ) {
 		Write-Warning $Error[0] |ForEach-Object {$_.Exception}
-		$errorhost = $Error[0] |ForEach-Object {$.TargetObject.RequestUri.Host}
+		$errorhost = $Error[0] |ForEach-Object {$_.TargetObject.RequestUri.Host}
 		Write-Output $errorhost 'へ接続できる事を確認してください'
 	}
 	elseif ( ($error | ForEach-Object {$_.Exception.Status}) -eq "ProtocolError" ) {
 		Write-Warning $Error[0] |ForEach-Object {$_.Exception}
-		$errorfile = $error | ForEach-Object {$.TargetObject.Address.OriginalString}
+		$errorfile = $error | ForEach-Object {$_.TargetObject.Address.OriginalString}
 		Write-Output $errorfile
 		Write-Output 'が見つかりませんでした'
 	}
 	else {
-		Write-Warning $Error[0] |ForEach-Object {$.Exception}
+		Write-Warning $Error[0] |ForEach-Object {$_.Exception}
 	}
 	exit 1
 }
+Write-Output '各種ライブラリのダウンロードが完了しました'
 #展開開始
+Write-Output '各種ライブラリのzip解凍を開始します'
 try {
 	Expand-Archive bass24.zip -Force
 	Expand-Archive bass_aac24.zip -Force
@@ -73,11 +75,11 @@ try {
 	Expand-Archive 7za920.zip -Force
 }
 catch {
-	if( ($Error[0] |ForEach-Object {$.CategoryInfo.Category}) -eq "InvalidOperation") {
+	if( ($Error[0] |ForEach-Object {$_.CategoryInfo.Category}) -eq "InvalidOperation") {
 		Write-Warning 'ファイル操作に失敗しました'
 		Write-Output 'ファイルが破損している可能性があります'
 	}
-	elseif( ($Error[0] |ForEach-Object {$.CategoryInfo.Category}) -eq "InvalidArgument") {
+	elseif( ($Error[0] |ForEach-Object {$_.CategoryInfo.Category}) -eq "InvalidArgument") {
 		Write-Warning 'ファイルが見つかりません'
 		Write-Output '削除された可能性があります'
 	}
@@ -88,3 +90,4 @@ Start-Process -FilePath ./7za920/7za.exe -ArgumentList "x mp3infpu_dll_255-beta3
 New-Item .backup -ItemType "directory" -Force| Out-Null
 Move-Item ./*.zip ./.backup/ -Force
 Move-Item ./mp3infpu_dll_*.7z ./.backup/ -Force
+Write-Output '各種ライブラリのzip解凍が完了しました'

--- a/getlibs.bat
+++ b/getlibs.bat
@@ -27,6 +27,7 @@ if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Community\Common7\Too
     echo "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
     SET /P VSDEVCMD="VsDevCmd.bat ‚ÌƒpƒX‚ð“ü—Í‚µ‚Ä‚­‚¾‚³‚¢->"
     if not exist "%VSDEVCMD%" (
+        echo "%VSDEVCMD%"
         echo [91m“ü—Í‚³‚ê‚½ƒpƒX‚ÉVsDevCmd.bat‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñ[37m
         goto ERROR_VSDEVCMD_NOT_FOUND
     )
@@ -48,7 +49,6 @@ powershell -ExecutionPolicy Unrestricted ./downloadlibs.ps1
 if %ERRORLEVEL% equ 1 (
     goto ERROR_FAILED_TO_GET_LIBS
 )
-pause
 
 echo ƒrƒ‹ƒh‚ª•K—v‚Èˆê•”‚Ìƒ‰ƒCƒuƒ‰ƒŠ‚ðƒrƒ‹ƒh‚µ‚Ü‚·
 
@@ -61,7 +61,6 @@ copy jconfig.vc jconfig.h
 nmake /f makefile.vc clean all
 cd ../../
 echo ===========================jpegsr9c‚Ìƒrƒ‹ƒhŠ®—¹===========================
-pause
 
 rem nezplug++‚Ìƒrƒ‹ƒh
 echo ===========================nezplug++‚Ìƒrƒ‹ƒhŠJŽn===========================
@@ -72,7 +71,6 @@ cd ../
 echo ===========================nezplug++‚Ìƒrƒ‹ƒhŠ®—¹===========================
 
 echo ƒrƒ‹ƒh‚ª•K—v‚Èˆê•”‚Ìƒ‰ƒCƒuƒ‰ƒŠ‚Ìƒrƒ‹ƒh‚ªŠ®—¹‚µ‚Ü‚µ‚½
-pause
 
 rem ƒ‰ƒCƒuƒ‰ƒŠ‚Ì”z’u
 echo ƒ‰ƒCƒuƒ‰ƒŠ‚Ì”z’u‚ðŠJŽn‚µ‚Ü‚·
@@ -88,6 +86,7 @@ echo [91mERROR_VSDEVCMD_NOT_FOUND: VsDevCmd.bat‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñ‚Å‚µ‚½
 echo ‚±‚Ìbat‚Å‚Í VisualStudio“à•”‚Ì VsDevCmd.bat ‚ªAˆê•”‚Ìƒ‰ƒCƒuƒ‰ƒŠ‚Ìƒrƒ‹ƒh‚É•K{‚Å‚·
 echo ‚±‚ÌƒGƒ‰[‚ÍVisualStudioCommunity‚ðÄƒCƒ“ƒXƒg[ƒ‹‚·‚é“™‚Å‰ðŒˆ‚·‚é‰Â”\«‚ª‚ ‚è‚Ü‚·
 echo ‰½‚©ƒL[‚ð‰Ÿ‚·‚ÆI—¹‚µ‚Ü‚·[37m
+pause
 goto :EOF
 
 :ERROR_FAILED_TO_GET_LIBS

--- a/getlibs.bat
+++ b/getlibs.bat
@@ -1,34 +1,108 @@
 @echo off
+rem ˆê•”‚Ìƒ‰ƒCƒuƒ‰ƒŠ‚Ìƒrƒ‹ƒh‚Ég‚¤Visual Studio“à•”‚Ìbat‚ğ’Tõ
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" (
+    SET VSDEVCMD="%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat"
+    echo %VSDEVCMD% ‚ªŒ©‚Â‚©‚è‚Ü‚µ‚½
+    echo Visual Studio Community 2022 ‚ğ—˜—p‚µ‚Ü‚·
+) else if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
+    SET VSDEVCMD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
+    echo %VSDEVCMD% ‚ªŒ©‚Â‚©‚è‚Ü‚µ‚½
+    echo Visual Studio Community 2017 ‚ğ—˜—p‚µ‚Ü‚·
+) else if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" (
+    SET VSDEVCMD="%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+    echo %VSDEVCMD% ‚ªŒ©‚Â‚©‚è‚Ü‚µ‚½
+    echo Visual Studio Enterprise 2022 ‚ğ—˜—p‚µ‚Ü‚·
+) else if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat" (
+    SET VSDEVCMD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
+    echo %VSDEVCMD% ‚ªŒ©‚Â‚©‚è‚Ü‚µ‚½
+    echo Visual Studio Enterprise 2017 ‚ğ—˜—p‚µ‚Ü‚·
+) else (
+    echo ƒCƒ“ƒXƒg[ƒ‹Ï‚İ‚ÌVisual Studio‚à‚µ‚­‚Í‚»‚Ì“à•”‚ÌVsDevCmd.bat‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñ‚Å‚µ‚½
+    echo Visual Studio‚ÌƒCƒ“ƒXƒg[ƒ‹æ‚ğƒfƒtƒHƒ‹ƒg‚©‚ç•ÏX‚µ‚Ä‚¢‚éê‡“™‚ªl‚¦‚ç‚ê‚Ü‚·
+    echo VsDevCmd.bat ‚ÌƒpƒX‚ğ“ü—Í‚µ‚Ä‚­‚¾‚³‚¢
+    echo —á:
+    echo "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+    echo "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat"
+    echo "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
+    echo "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
+    SET /P VSDEVCMD="VsDevCmd.bat ‚ÌƒpƒX‚ğ“ü—Í‚µ‚Ä‚­‚¾‚³‚¢->"
+    if not exist "%VSDEVCMD%" (
+        echo [91m“ü—Í‚³‚ê‚½ƒpƒX‚ÉVsDevCmd.bat‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñ[37m
+        goto ERROR_VSDEVCMD_NOT_FOUND
+    )
+)
+
+rem Microsoft Windows SDK for Windows 7 and .NET Framework 4‚ğ’Tõ
+if exist "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v7.1A\Include" (
+    SET INCLUDE_DIR="%ProgramFiles(x86)%"\"Microsoft SDKs"\Windows\v7.1A\Include
+) else if exist "%ProgramW6432%\Microsoft SDKs\Windows\v7.1\Include" (
+    SET INCLUDE_DIR="%ProgramW6432%"\"Microsoft SDKs"\Windows\v7.1\Include
+) else (
+    goto ERROR_SDK_NOT_FOUND
+)
+
+rem ƒ‰ƒCƒuƒ‰ƒŠ‚Ìƒ_ƒEƒ“ƒ[ƒh‚Æzip“WŠJ
 echo Às’†‚ÍPowerShell‚Ì‰æ–Ê‚ª•\¦‚³‚ê‚Ü‚·
 echo ‰æ–Ê‚É‚ÍG‚ç‚¸‚»‚Ì‚Ü‚Ü‚Å‚¨‘Ò‚¿‚­‚¾‚³‚¢
-cd ./
 powershell -ExecutionPolicy Unrestricted ./downloadlibs.ps1
-cd ./jpegsr9c/jpeg-9c
-call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
-SET dir=%ProgramFiles(x86)%\Microsoft SDKs\Windows\v7.1A\Include
-if exist "%dir%\" goto CONTINUE
-SET dir=%ProgramW6432%\Microsoft SDKs\Windows\v7.1\Include
-if exist "%dir%\" goto CONTINUE
-goto ERROR
+if %ERRORLEVEL% equ 1 (
+    goto ERROR_FAILED_TO_GET_LIBS
+)
+pause
 
-:CONTINUE
-SET Include=%Include%;%dir%
+echo ƒrƒ‹ƒh‚ª•K—v‚Èˆê•”‚Ìƒ‰ƒCƒuƒ‰ƒŠ‚ğƒrƒ‹ƒh‚µ‚Ü‚·
+
+rem jpeglib‚ğƒrƒ‹ƒh
+echo ===========================jpegsr9c‚Ìƒrƒ‹ƒhŠJn===========================
+cd ./jpegsr9c/jpeg-9c
+call "%VSDEVCMD%"
+SET Include=%Include%;%INCLUDE_DIR%
 copy jconfig.vc jconfig.h
 nmake /f makefile.vc clean all
 cd ../../
+echo ===========================jpegsr9c‚Ìƒrƒ‹ƒhŠ®—¹===========================
+pause
+
+rem nezplug++‚Ìƒrƒ‹ƒh
+echo ===========================nezplug++‚Ìƒrƒ‹ƒhŠJn===========================
 powershell -ExecutionPolicy Unrestricted ./makelibs.ps1
 cd ./nezplug++/
 lib /DEF:npnez.def /MACHINE:x86 /out:npnez.lib
 cd ../
+echo ===========================nezplug++‚Ìƒrƒ‹ƒhŠ®—¹===========================
+
+echo ƒrƒ‹ƒh‚ª•K—v‚Èˆê•”‚Ìƒ‰ƒCƒuƒ‰ƒŠ‚Ìƒrƒ‹ƒh‚ªŠ®—¹‚µ‚Ü‚µ‚½
+pause
+
+rem ƒ‰ƒCƒuƒ‰ƒŠ‚Ì”z’u
+echo ƒ‰ƒCƒuƒ‰ƒŠ‚Ì”z’u‚ğŠJn‚µ‚Ü‚·
 powershell -ExecutionPolicy Unrestricted ./copylibs.ps1
-cls
-echo ˆ—‚ªŠ®—¹‚µ‚Ü‚µ‚½
+echo ƒ‰ƒCƒuƒ‰ƒŠ‚Ì”z’u‚ªŠ®—¹‚µ‚Ü‚µ‚½
 echo ‰½‚©ƒL[‚ğ‰Ÿ‚·‚ÆI—¹‚µ‚Ü‚·
 pause
 goto :EOF
 
-:ERROR
-echo •K—v‚ÈSDK‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñ‚Å‚µ‚½
+rem ƒGƒ‰[ˆ—
+:ERROR_VSDEVCMD_NOT_FOUND
+echo [91mERROR_VSDEVCMD_NOT_FOUND: VsDevCmd.bat‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñ‚Å‚µ‚½
+echo ‚±‚Ìbat‚Å‚Í VisualStudio“à•”‚Ì VsDevCmd.bat ‚ªAˆê•”‚Ìƒ‰ƒCƒuƒ‰ƒŠ‚Ìƒrƒ‹ƒh‚É•K{‚Å‚·
+echo ‚±‚ÌƒGƒ‰[‚ÍVisualStudioCommunity‚ğÄƒCƒ“ƒXƒg[ƒ‹‚·‚é“™‚Å‰ğŒˆ‚·‚é‰Â”\«‚ª‚ ‚è‚Ü‚·
+echo ‰½‚©ƒL[‚ğ‰Ÿ‚·‚ÆI—¹‚µ‚Ü‚·[37m
+goto :EOF
+
+:ERROR_FAILED_TO_GET_LIBS
+echo [91mERROR_FAILED_TO_GET_LIBS: ƒ‰ƒCƒuƒ‰ƒŠ‚Ìƒ_ƒEƒ“ƒ[ƒh‚É¸”s‚µ‚Ü‚µ‚½
+echo ˆÈ‰º‚Ìƒy[ƒW‚©‚çissue‚ğ‹N•[‚µ‚Ä‚­‚¾‚³‚¢
+echo https://github.com/ryotayama/hayaemon_windows/issues
+echo ‰½‚©ƒL[‚ğ‰Ÿ‚·‚ÆI—¹‚µ‚Ü‚·[37m
+pause
+goto :EOF
+
+:ERROR_SDK_NOT_FOUND
+cd ../../
+echo [91mERROR_SDK_NOT_FOUND: •K—v‚ÈSDK‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñ‚Å‚µ‚½
 echo Microsoft Windows SDK for Windows 7 and .NET Framework 4 ‚ğƒCƒ“ƒXƒg[ƒ‹‚µ‚Ä‚­‚¾‚³‚¢
 echo https://www.microsoft.com/en-us/download/details.aspx?id=8279
+echo ‰½‚©ƒL[‚ğ‰Ÿ‚·‚ÆI—¹‚µ‚Ü‚·[37m
 pause
+goto :EOF

--- a/getlibs.bat
+++ b/getlibs.bat
@@ -1,20 +1,22 @@
 @echo off
+SETLOCAL enabledelayedexpansion
+
 rem ˆê•”‚Ìƒ‰ƒCƒuƒ‰ƒŠ‚Ìƒrƒ‹ƒh‚Ég‚¤Visual Studio“à•”‚Ìbat‚ğ’Tõ
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" (
     SET VSDEVCMD="%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat"
-    echo %VSDEVCMD% ‚ªŒ©‚Â‚©‚è‚Ü‚µ‚½
+    echo !VSDEVCMD! ‚ªŒ©‚Â‚©‚è‚Ü‚µ‚½
     echo Visual Studio Community 2022 ‚ğ—˜—p‚µ‚Ü‚·
 ) else if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
     SET VSDEVCMD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
-    echo %VSDEVCMD% ‚ªŒ©‚Â‚©‚è‚Ü‚µ‚½
+    echo !VSDEVCMD! ‚ªŒ©‚Â‚©‚è‚Ü‚µ‚½
     echo Visual Studio Community 2017 ‚ğ—˜—p‚µ‚Ü‚·
 ) else if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" (
     SET VSDEVCMD="%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
-    echo %VSDEVCMD% ‚ªŒ©‚Â‚©‚è‚Ü‚µ‚½
+    echo !VSDEVCMD! ‚ªŒ©‚Â‚©‚è‚Ü‚µ‚½
     echo Visual Studio Enterprise 2022 ‚ğ—˜—p‚µ‚Ü‚·
 ) else if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat" (
     SET VSDEVCMD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
-    echo %VSDEVCMD% ‚ªŒ©‚Â‚©‚è‚Ü‚µ‚½
+    echo !VSDEVCMD! ‚ªŒ©‚Â‚©‚è‚Ü‚µ‚½
     echo Visual Studio Enterprise 2017 ‚ğ—˜—p‚µ‚Ü‚·
 ) else (
     echo ƒCƒ“ƒXƒg[ƒ‹Ï‚İ‚ÌVisual Studio‚à‚µ‚­‚Í‚»‚Ì“à•”‚ÌVsDevCmd.bat‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñ‚Å‚µ‚½
@@ -26,8 +28,8 @@ if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Community\Common7\Too
     echo "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
     echo "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
     SET /P VSDEVCMD="VsDevCmd.bat ‚ÌƒpƒX‚ğ“ü—Í‚µ‚Ä‚­‚¾‚³‚¢->"
-    if not exist "%VSDEVCMD%" (
-        echo "%VSDEVCMD%"
+    if not exist "!VSDEVCMD!" (
+        echo "!VSDEVCMD!"
         echo [91m“ü—Í‚³‚ê‚½ƒpƒX‚ÉVsDevCmd.bat‚ªŒ©‚Â‚©‚è‚Ü‚¹‚ñ[37m
         goto ERROR_VSDEVCMD_NOT_FOUND
     )
@@ -46,7 +48,7 @@ rem ƒ‰ƒCƒuƒ‰ƒŠ‚Ìƒ_ƒEƒ“ƒ[ƒh‚Æzip“WŠJ
 echo Às’†‚ÍPowerShell‚Ì‰æ–Ê‚ª•\¦‚³‚ê‚Ü‚·
 echo ‰æ–Ê‚É‚ÍG‚ç‚¸‚»‚Ì‚Ü‚Ü‚Å‚¨‘Ò‚¿‚­‚¾‚³‚¢
 powershell -ExecutionPolicy Unrestricted ./downloadlibs.ps1
-if %ERRORLEVEL% equ 1 (
+if !ERRORLEVEL! equ 1 (
     goto ERROR_FAILED_TO_GET_LIBS
 )
 
@@ -55,8 +57,8 @@ echo ƒrƒ‹ƒh‚ª•K—v‚Èˆê•”‚Ìƒ‰ƒCƒuƒ‰ƒŠ‚ğƒrƒ‹ƒh‚µ‚Ü‚·
 rem jpeglib‚ğƒrƒ‹ƒh
 echo ===========================jpegsr9c‚Ìƒrƒ‹ƒhŠJn===========================
 cd ./jpegsr9c/jpeg-9c
-call "%VSDEVCMD%"
-SET Include=%Include%;%INCLUDE_DIR%
+call %VSDEVCMD%
+SET Include=!Include!;!INCLUDE_DIR!
 copy jconfig.vc jconfig.h
 nmake /f makefile.vc clean all
 cd ../../
@@ -105,3 +107,5 @@ echo https://www.microsoft.com/en-us/download/details.aspx?id=8279
 echo ‰½‚©ƒL[‚ğ‰Ÿ‚·‚ÆI—¹‚µ‚Ü‚·[37m
 pause
 goto :EOF
+
+ENDLOCAL


### PR DESCRIPTION
以下修正内容です～
さらりと確認お願いします。



解析したところ http://soft.edolfzoku.com/hayaemon2/Hayaemon276.zip にアクセスできず、それ以降にダウンロードするものすべてダウンロードできてなかった。

その後もエラー処理内にそもそものコードのミス（”$_.”であるべきところが"$."になっていたり）があったので修正。
ついでにVsDevCmd.batもVisual Studio Community 2017の決め打ちになっていたのを4択追加（CommunityとEnterpriseの2017、2022をそれぞれ）
さらに、その4択で見つからないときはユーザに入力させるようにした。

あとはエラー起きた時にトレーサビリティ低かったので、どこで何をして死んだかある程度わかるようにログとコメントを増やして可読性とトレーサビリティを向上させた。

https://github.com/ryotayama/hayaemon_windows/commit/2fd9bfb218db2553361f9eb958400f772441ced5

Close #488